### PR TITLE
[Client ]토큰이 없어도 로그인이 유지되는 현상 수정

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useNavigate, Routes, Route } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
 import axios from 'axios'
@@ -6,6 +6,7 @@ import axios from 'axios'
 import Profile from './section/profile'
 import Board from './section/board'
 import LandingPage from './section/landing'
+import { getProjects } from './actions/projects'
 
 const savedUserInfo = window.localStorage.getItem('userinfo')
 const url = new URL(window.location.href)
@@ -15,6 +16,11 @@ const stateCode = url.searchParams.get('state')
 const gitcode = window.localStorage.getItem('gitcode')
 
 axios.defaults.withCredentials = true
+
+// App.js 가 unload될 때 호출할 이벤트입니다.
+window.addEventListener('beforeunload', (e) => {
+  localStorage.removeItem('userInfo')
+})
 
 function App() {
   const [isSignup, setIsSignup] = useState(false)
@@ -110,9 +116,9 @@ function App() {
   //     })
   // }
 
-  // useEffect(() => {
-  //   getAccessTocken(authorizationCode)
-  // }, [authorizationCode])
+  useEffect(() => {
+    dispatch(getProjects())
+  }, [])
 
   return (
     <Routes>

--- a/client/src/actions/login.js
+++ b/client/src/actions/login.js
@@ -19,7 +19,7 @@ export const handleLoggedOut = () => {
   }
 }
 
-const login = (userInfo) => {
+export const login = (userInfo) => {
   return {
     type: LOGGED_IN,
     payload: { ...userInfo },

--- a/client/src/actions/projects.js
+++ b/client/src/actions/projects.js
@@ -1,5 +1,7 @@
 import axios from 'axios'
+import { login } from './login'
 
+const serverUrl = process.env.REACT_APP_API__URL
 export const PROJECTS = 'PROJECTS'
 
 const projects = (projects) => {
@@ -12,10 +14,24 @@ const projects = (projects) => {
 }
 
 export const getProjects = () => async (dispatch) => {
-  try {
-    const { data } = await axios.get(process.env.REACT_APP_API__URL + '/projects')
-    dispatch(projects(data.list))
-  } catch (err) {
-    console.log('공개게시판 불러오는 과정에서 발생한 오류입니다.', err)
-  }
+  // 공개게시판을 불러옵니다.
+  axios
+    .get(serverUrl + '/projects')
+    .then(({ data }) => {
+      // ! 게시글을 최신순으로 보여주기 위해 reverse()를 통해 일시적으로 배열 순서를 뒤집었지만 서버에서 최신순으로 데이터를 건네받도록 수정이 필요합니다.
+      dispatch(projects(data.list.reverse()))
+    })
+    .catch((err) => console.log('공개게시판 불러오는 과정에서 발생한 오류입니다.', err))
+
+  // 유저가 로그인 상태인지 확인합니다.
+  axios.get(serverUrl + '/users').then(({ data }) => {
+    // 로그인한 상태가 아니더라도 서버에서는 200코드를 주기때문에 응답메세지로 조건분기합니다.
+    if (data.message === 'invailid authorization') return
+    else {
+      // App.js에서 새로고침 직후 삭제된 로컬스토리지 'userInfo'를 새로 채워넣습니다.
+      window.localStorage.setItem('userInfo', JSON.stringify(data.data))
+      // 리덕스 loginReducer에 유저정보를 입력합니다.
+      dispatch(login(data.data))
+    }
+  })
 }

--- a/client/src/reducer/projectDetailReducer.js
+++ b/client/src/reducer/projectDetailReducer.js
@@ -2,7 +2,6 @@ import { PROJECT_DETAIL } from '../actions/projectDetial'
 
 const projectDetailLoc = window.localStorage.getItem(PROJECT_DETAIL)
 const projectDetail = projectDetailLoc ? JSON.parse(projectDetailLoc) : null
-console.log(projectDetail)
 
 const initialState = {
   title: projectDetail ? projectDetail.title : '',

--- a/client/src/section/board/components/projects/content.js
+++ b/client/src/section/board/components/projects/content.js
@@ -43,17 +43,11 @@ const Floor = styled.div`
 
 const Content = () => {
   const { projects } = useSelector((state) => state.projectsReducer)
-  const dispatch = useDispatch()
-  const location = useLocation()
-
-  useEffect(() => {
-    dispatch(getProjects())
-  }, [])
 
   return (
     <Container>
       <Wrapper>
-        {projects.reverse().map((project, idx, projects) => {
+        {projects.map((project, idx, projects) => {
           if (idx % 3 !== 0) return
           else
             return (

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -10,7 +10,11 @@ module.exports = {
       //쿠키로 받은 Token을 함수를 사용해 디코딩한다.
       if (!req.cookies.jwt) {
         console.log('\n❗️ users(userInfo):\n 토큰정보를 확인할 수 없습니다.\n')
-        return res.status(401).json({ message: 'invailid authorization' })
+        // return res.status(401).json({ message: 'invailid authorization' })
+        // ! 기존엔 로그인 로직에 사용됐었고 401코드를 주게돼있었지만,
+        // ! 현재는 새로고침시 유저정보를 불러오게 할 때 사용돼서 클라이언트에서 오류메세지를 별도로 보여주지않기위해 200으로 일시 수정했습니다.
+        // ! 2022.3.5 최재하
+        return res.status(200).json({ message: 'invailid authorization' })
       }
       const token = req.cookies.jwt
       const decoded = solveToken(token)
@@ -92,6 +96,7 @@ module.exports = {
             domain: process.env.DOMAIN,
             secure: true,
             sameSite: 'none',
+            httpOnly: true,
           })
           .json({ message: 'byebye' })
       }
@@ -176,6 +181,7 @@ module.exports = {
           domain: process.env.DOMAIN,
           secure: true,
           sameSite: 'none',
+          httpOnly: true,
         })
         .send('Logged out successfully')
     },
@@ -250,6 +256,7 @@ module.exports = {
             domain: process.env.DOMAIN,
             secure: true,
             sameSite: 'none',
+            httpOnly: true,
           })
           .status(201)
           .json({
@@ -298,6 +305,7 @@ module.exports = {
             domain: process.env.DOMAIN,
             secure: true,
             sameSite: 'none',
+            httpOnly: true,
           })
           .status(200)
           .json({


### PR DESCRIPTION
기존에 토큰이 담긴 쿠키가 만료되거나 사라져도 로컬스토리지에 있는 유저 정보로 뷰상에는 로그인된 상태로 보이는 현상이있었습니다.
이 문제는 토큰이 없고 로컬스토리지 유저정보가 있거나 그 반대 상황에서 문제를 일으키는데,
사이트를 새로고침을하거나 처음 방문했을 때  서버에서 유저정보를 가져오는 요청을 보냅니다. 
새로고침을 하거나 끌때는 로컬스토리지에 있는 유저정보를 반드시 지우고 새로고침/최초방문시 에는 유저정보를 받아와서 로컬스토리지에 담는 과정을 반드시 거칩니다.

해당방법으로 기존 문제는 해결되었으나 최초렌더링시 순간적으로 깜빡이고 로그인이 안된상태가 1초 이하로 보입니다. 지속적으로 해결방법을 찾아봐야합니다.